### PR TITLE
compatible with new ggplot2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,4 +33,4 @@ ByteCompile: true
 License: Artistic-2.0
 URL: https://github.com/GuangchuangYu/meme/
 BugReports: https://github.com/GuangchuangYu/meme/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.3.2

--- a/vignettes/meme.Rmd
+++ b/vignettes/meme.Rmd
@@ -106,19 +106,8 @@ plot(x, size = 2, "happy friday!", "wait, sorry, it's monday", color = "firebric
 
 ## `+` method
 
-
-Instead of using parameters in `plot()` explictely, Users can use `+ aes()` to set the plot parameters:
-
-
-```{r fig.width=7, fig.height = 3.94}
-x + aes(upper = "#barbarplots",
-        lower = "friends don't let friends make bar plots",
-        color = firebrick, font = Courier, size=1.5)
-```
-
-or using `+ list()`. The following command will also generate the figure
-displayed above.
-
+Instead of using parameters in `plot()` explictely, Users can use `+ list()` to set the plot parameters:
+ 
 ```{r fig.width=7, fig.height = 3.94, eval=FALSE}
 x + list(upper = "#barbarplots",
         lower = "friends don't let friends make bar plots",
@@ -172,7 +161,7 @@ ggplot(d, aes(x, y)) + geom_line() +
     geom_subview(aes(x, y), data=d, subview=mm, width=.3, height=.15)
 
 ggplot(d, aes(x, y)) +
-    geom_subview(x = 0, y = 0, subview=mm+aes(size=3), width=Inf, height=Inf) +
+    geom_subview(x = 0, y = 0, subview=mm+list(size=3), width=Inf, height=Inf) +
     geom_point() + geom_line()
 ```
 


### PR DESCRIPTION
`+.meme`方法目前还是不能与ggplot2的S7框架很好兼容，尝试了他们之前提出的[解决方法](https://github.com/RConsortium/S7/issues/544#issuecomment-3028371548)，meme + aes()始终返回NULL.但是meme + list()是可以工作的。
相同的问题:
+ https://github.com/tidyverse/ggplot2/issues/6504
+ https://github.com/nlmixr2/nlmixr2plot/issues/39